### PR TITLE
Print the error

### DIFF
--- a/kafkazerolog/kafkazerolog.go
+++ b/kafkazerolog/kafkazerolog.go
@@ -78,7 +78,7 @@ func (kw *kafkaWriter) Write(p []byte) (int, error) {
 	if err := kw.producer.WriteMessages(context.Background(), kafka.Message{
 		Value: sendMessage,
 	}); err != nil {
-		fmt.Println("Unable to send the log message to Kafka")
+		fmt.Println("Unable to send the log message to Kafka:", err)
 	}
 
 	return len(p), nil


### PR DESCRIPTION
It's very hard to debug what's going on while logging, so this package should print the error message too.